### PR TITLE
Improve token refreshing

### DIFF
--- a/lib/src/oauth_chopper.dart
+++ b/lib/src/oauth_chopper.dart
@@ -68,17 +68,17 @@ class OAuthChopper {
   OAuthInterceptor get interceptor => OAuthInterceptor(this);
 
   /// Tries to refresh the available credentials and returns a new [OAuthToken] instance.
-  /// Throws an exception when refreshing fails. See [Credentials.refresh]
+  /// Throws an exception when refreshing fails. If the exception is a [AuthorizationException] it clears the storage.
+  /// See [Credentials.refresh]
   Future<OAuthToken?> refresh() async {
     final credentialsJson = await _storage.fetchCredentials();
     if (credentialsJson == null) return null;
     final credentials = Credentials.fromJson(credentialsJson);
     try {
-      final newCredentials =
-          await credentials.refresh(identifier: identifier, secret: secret);
+      final newCredentials = await credentials.refresh(identifier: identifier, secret: secret);
       await _storage.saveCredentials(newCredentials.toJson());
       return OAuthToken.fromCredentials(newCredentials);
-    } catch (e) {
+    } on AuthorizationException {
       _storage.clear();
       rethrow;
     }

--- a/lib/src/oauth_chopper.dart
+++ b/lib/src/oauth_chopper.dart
@@ -75,7 +75,8 @@ class OAuthChopper {
     if (credentialsJson == null) return null;
     final credentials = Credentials.fromJson(credentialsJson);
     try {
-      final newCredentials = await credentials.refresh(identifier: identifier, secret: secret);
+      final newCredentials =
+          await credentials.refresh(identifier: identifier, secret: secret);
       await _storage.saveCredentials(newCredentials.toJson());
       return OAuthToken.fromCredentials(newCredentials);
     } on AuthorizationException {


### PR DESCRIPTION
Only clear storage when Credentials refresh trigger a authorization exception. Instead of every exception. 
