### PR TITLE
:sparkles: Add custom http client

### DIFF
--- a/lib/src/oauth_chopper.dart
+++ b/lib/src/oauth_chopper.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:oauth2/oauth2.dart';
+import 'package:oauth2/oauth2.dart' as oauth2;
 import 'package:oauth_chopper/src/oauth_authenticator.dart';
 import 'package:oauth_chopper/src/oauth_grant.dart';
 import 'package:oauth_chopper/src/oauth_interceptor.dart';
@@ -73,13 +73,13 @@ class OAuthChopper {
   Future<OAuthToken?> refresh() async {
     final credentialsJson = await _storage.fetchCredentials();
     if (credentialsJson == null) return null;
-    final credentials = Credentials.fromJson(credentialsJson);
+    final credentials = oauth2.Credentials.fromJson(credentialsJson);
     try {
       final newCredentials =
           await credentials.refresh(identifier: identifier, secret: secret);
       await _storage.saveCredentials(newCredentials.toJson());
       return OAuthToken.fromCredentials(newCredentials);
-    } on AuthorizationException {
+    } on oauth2.AuthorizationException {
       _storage.clear();
       rethrow;
     }
@@ -89,7 +89,7 @@ class OAuthChopper {
   /// Currently supported grants:
   ///  - [ResourceOwnerPasswordGrant]
   ///  - [ClientCredentialsGrant]
-  ///
+  ///  - [AuthorizationCodeGrant]
   /// Throws an exception if the grant fails.
   Future<OAuthToken> requestGrant(OAuthGrant grant) async {
     final credentials =

--- a/lib/src/oauth_chopper.dart
+++ b/lib/src/oauth_chopper.dart
@@ -56,7 +56,9 @@ class OAuthChopper {
   /// Get stored [OAuthToken].
   Future<OAuthToken?> get token async {
     final credentialsJson = await _storage.fetchCredentials();
-    return credentialsJson != null ? OAuthToken.fromJson(credentialsJson) : null;
+    return credentialsJson != null
+        ? OAuthToken.fromJson(credentialsJson)
+        : null;
   }
 
   /// Provides an [OAuthAuthenticator] instance.
@@ -98,7 +100,8 @@ class OAuthChopper {
   ///  - [AuthorizationCodeGrant]
   /// Throws an exception if the grant fails.
   Future<OAuthToken> requestGrant(OAuthGrant grant) async {
-    final credentials = await grant.handle(authorizationEndpoint, identifier, secret, httpClient);
+    final credentials = await grant.handle(
+        authorizationEndpoint, identifier, secret, httpClient);
 
     await _storage.saveCredentials(credentials);
 

--- a/lib/src/oauth_grant.dart
+++ b/lib/src/oauth_grant.dart
@@ -17,7 +17,8 @@ class ResourceOwnerPasswordGrant extends OAuthGrant {
   final String username;
   final String password;
 
-  const ResourceOwnerPasswordGrant({required this.username, required this.password});
+  const ResourceOwnerPasswordGrant(
+      {required this.username, required this.password});
 
   @override
   Future<String> handle(
@@ -88,10 +89,12 @@ class AuthorizationCodeGrant extends OAuthGrant {
       tokenEndpoint,
       httpClient: httpClient,
     );
-    var authorizationUrl = grant.getAuthorizationUrl(redirectUrl, scopes: scopes);
+    var authorizationUrl =
+        grant.getAuthorizationUrl(redirectUrl, scopes: scopes);
     await redirect(authorizationUrl);
     var responseUrl = await listen(redirectUrl);
-    oauth.Client client = await grant.handleAuthorizationResponse(responseUrl.queryParameters);
+    oauth.Client client =
+        await grant.handleAuthorizationResponse(responseUrl.queryParameters);
 
     return client.credentials.toJson();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
 
 dependencies:
   chopper: ^7.2.0
+  http: ^1.2.1
   oauth2: ^2.0.2
 
 dev_dependencies:
-  http: ^1.2.1
   lints: ">=2.1.1 <4.0.0"
   mocktail: ^1.0.3
   test: ^1.25.2

--- a/test/oauth_chopper_test.dart
+++ b/test/oauth_chopper_test.dart
@@ -101,7 +101,8 @@ void main() {
     final token = await oauthChopper.requestGrant(grantMock);
 
     // assert
-    verify(() => grantMock.handle(any(), 'identifier', 'secret', null)).called(1);
+    verify(() => grantMock.handle(any(), 'identifier', 'secret', null))
+        .called(1);
     verify(() => storageMock.saveCredentials(testJson)).called(1);
     expect(token.accessToken, 'accesToken');
     expect(token.idToken, 'idToken');

--- a/test/oauth_chopper_test.dart
+++ b/test/oauth_chopper_test.dart
@@ -89,7 +89,7 @@ void main() {
   test("Successful grant is stored", () async {
     // arrange
     when(() => storageMock.saveCredentials(any())).thenAnswer((_) => null);
-    when(() => grantMock.handle(any(), any(), any()))
+    when(() => grantMock.handle(any(), any(), any(), null))
         .thenAnswer((_) async => testJson);
     final oauthChopper = OAuthChopper(
         authorizationEndpoint: Uri.parse('endpoint'),
@@ -101,7 +101,7 @@ void main() {
     final token = await oauthChopper.requestGrant(grantMock);
 
     // assert
-    verify(() => grantMock.handle(any(), 'identifier', 'secret')).called(1);
+    verify(() => grantMock.handle(any(), 'identifier', 'secret', null)).called(1);
     verify(() => storageMock.saveCredentials(testJson)).called(1);
     expect(token.accessToken, 'accesToken');
     expect(token.idToken, 'idToken');


### PR DESCRIPTION
Added possibility to pass a custom http client. Which will also be passed to oauth2 to make use of it.  See #13 