### PR TITLE
:sparkles: Added more oauth2 package parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.1.0
+- Synced oauth_chopper with auth2 package. This makes more parameters available which are supported by oauth2.
+  - Be default `OAuthChopper` client can now also be provided with the following parameter. Which will be passed to oauth2.
+    - `scopes`
+    - `basicAuth`
+    - `delimiter`
+    - `getParameters`
+  - Added `newScopes` & `basicAuth` parameters to `OAuthChopper.refresh` which wil be passed to oauth2
+  - BREAKING: `scopes` has been removed from `AuthorizationCodeGrant`. These are now provided in the `OAuthChopper` client.
+  - BREAKING: `OAuthGrant.handle` has been extended to support new parameters as optional named parameters, `including` secret and `httpClient`.
+
 ## 1.0.1
 - Updated dependencies:
   - `sdk` to `>=3.4.0 <4.0.0`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: oauth_chopper
 description: Add and manage OAuth2 authentication for your Chopper client.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/DutchCodingCompany/oauth_chopper
 
 environment:
@@ -9,7 +9,8 @@ environment:
 dependencies:
   chopper: ^8.0.1+1
   http: ^1.2.2
-  oauth2: ^2.0.2
+  http_parser: ^4.1.0
+  oauth2: ^2.0.3
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/test/oauth_chopper_test.dart
+++ b/test/oauth_chopper_test.dart
@@ -78,8 +78,18 @@ void main() {
   test('Successful grant is stored', () async {
     // arrange
     when(() => storageMock.saveCredentials(any())).thenAnswer((_) => null);
-    when(() => grantMock.handle(any(), any(), any(), null))
-        .thenAnswer((_) async => testJson);
+    when(
+      () => grantMock.handle(
+        any(),
+        any(),
+        secret: any(named: 'secret'),
+        basicAuth: any(named: 'basicAuth'),
+        httpClient: any(named: 'httpClient'),
+        delimiter: any(named: 'delimiter'),
+        getParameters: any(named: 'getParameters'),
+        scopes: any(named: 'scopes'),
+      ),
+    ).thenAnswer((_) async => testJson);
     final oauthChopper = OAuthChopper(
       authorizationEndpoint: Uri.parse('endpoint'),
       identifier: 'identifier',
@@ -91,7 +101,7 @@ void main() {
     final token = await oauthChopper.requestGrant(grantMock);
 
     // assert
-    verify(() => grantMock.handle(any(), 'identifier', 'secret', null))
+    verify(() => grantMock.handle(any(), 'identifier', secret: 'secret'))
         .called(1);
     verify(() => storageMock.saveCredentials(testJson)).called(1);
     expect(token.accessToken, 'accesToken');


### PR DESCRIPTION
Fixes: #24 

- Synced oauth_chopper with auth2 package. This makes more parameters available which are supported by oauth2.
  - Be default `OAuthChopper` client can now also be provided with the following parameter. Which will be passed to oauth2.
    - `scopes`
    - `basicAuth`
    - `delimiter`
    - `getParameters`
  - Added `newScopes` & `basicAuth` parameters to `OAuthChopper.refresh` which wil be passed to oauth2
  - BREAKING: `scopes` has been removed from `AuthorizationCodeGrant`. These are now provided in the `OAuthChopper` client.
  - BREAKING: `OAuthGrant.handle` has been extended to support new parameters as optional named parameters, `including` secret and `httpClient`.