### PR TITLE
v1.1.1 chore update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.1.1
 - Updated dependencies:
   - `sdk` to `^3.6.1`
-  - `flutter` to `>=3.27.0`
   - `chopper` to `8.0.4`
   - `http` to `1.3.0`
   - `http_parser` to `4.1.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.1
+- Updated dependencies:
+  - `sdk` to `^3.6.1`
+  - `flutter` to `>=3.27.0`
+  - `chopper` to `8.0.4`
+  - `http` to `1.3.0`
+  - `http_parser` to `4.1.2`
+  - `test` to `1.25.14`
+  - `very_good_analysis` to `7.0.0`
+
 ## 1.1.0
 - Synced oauth_chopper with auth2 package. This makes more parameters available which are supported by oauth2.
   - Be default `OAuthChopper` client can now also be provided with the following parameter. Which will be passed to oauth2.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Dutch Coding Company B.V.
+Copyright (c) 2025 Dutch Coding Company B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/oauth_chopper.dart
+++ b/lib/oauth_chopper.dart
@@ -1,7 +1,7 @@
 /// OAuthChopper for configuring OAuth authentication with Chopper.
 ///
 /// More dartdocs go here.
-library oauth_chopper;
+library;
 
 export 'package:oauth2/src/authorization_exception.dart';
 export 'package:oauth2/src/expiration_exception.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,19 @@
 name: oauth_chopper
 description: Add and manage OAuth2 authentication for your Chopper client.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/DutchCodingCompany/oauth_chopper
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: ^3.6.1
+  flutter: ">=3.27.0"
 
 dependencies:
-  chopper: ^8.0.1+1
-  http: ^1.2.2
-  http_parser: ^4.1.0
+  chopper: ^8.0.4
+  http: ^1.3.0
+  http_parser: ^4.1.2
   oauth2: ^2.0.3
 
 dev_dependencies:
   mocktail: ^1.0.4
-  test: ^1.25.7
-  very_good_analysis: ^6.0.0
+  test: ^1.25.14
+  very_good_analysis: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,6 @@ homepage: https://github.com/DutchCodingCompany/oauth_chopper
 
 environment:
   sdk: ^3.6.1
-  flutter: ">=3.27.0"
 
 dependencies:
   chopper: ^8.0.4


### PR DESCRIPTION
- Updated dependencies:
    - `sdk` to `^3.6.1`
    - `chopper` to `8.0.4`
    - `http` to `1.3.0`
    - `http_parser` to `4.1.2`
    - `test` to `1.25.14`
    - `very_good_analysis` to `7.0.0`